### PR TITLE
Fix importing

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -55,8 +55,16 @@ func main() {
 		os.Exit(1)
 		return
 	}
+	machineID := os.Getenv("PG_MACHINE_ID")
 
-	targetURI := fmt.Sprintf("postgres://postgres:%s@%s.internal:5432", operatorPass, appName)
+	appDomain := appName + ".internal"
+	if machineID != "" {
+		appDomain = machineID + ".vm." + appDomain
+	} else {
+		log.Println("[warn] PG_MACHINE_ID was not specified, falling back to resolving from app name")
+	}
+
+	targetURI := fmt.Sprintf("postgres://postgres:%s@%s:5432", operatorPass, appDomain)
 
 	opts := migrationOpts{
 		sourceURI: sourceURI,

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -174,5 +174,5 @@ func runCommand(cmdStr string) ([]byte, error) {
 	cmd := exec.Command("sh", "-c", cmdStr)
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
 
-	return cmd.Output()
+	return cmd.CombinedOutput()
 }


### PR DESCRIPTION
Instead of trying to connect to `<appname>.internal` and hoping that SkipDNSRegistration does the job, we can just guarantee that importing works by connecting to a known postgres machine (`<machine_id>.vm.<appname>.internal`)

Related to:
https://github.com/superfly/flyctl/pull/3401